### PR TITLE
Add "Sync url" script from Christophe and release it automatically

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,67 @@
+name: Package Application with Pyinstaller
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: "Install dependencies"
+      run: "pip install setuptools pyinstaller rich requests beautifulsoup4 -f --upgrade"
+
+    - name: "Install sync_url.py"
+      run: "pyinstaller sync_url.py -F"
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "Pferd Sync URL"
+        path: "dist/sync_url*"
+
+  release:
+    name: Release
+
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Download artifacts"
+      uses: actions/download-artifact@v2
+      with:
+        name: "Pferd Sync URL"
+
+    - name: "look at folder structure"
+      run: "ls -lah"
+
+    - name: "Create release"
+      uses: softprops/action-gh-release@v1
+
+    - name: "Upload release artifacts"
+      uses: softprops/action-gh-release@v1
+      with:
+        body: "Download sync_url (or sync_url.exe on Windows) and run it in the terminal or CMD."
+        files: |
+          sync_url
+          sync_url.exe

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build/
 .env
 .vscode
 ilias_cookies.txt
+
+# PyInstaller
+sync_url.spec
+dist/

--- a/PFERD/ilias/crawler.py
+++ b/PFERD/ilias/crawler.py
@@ -116,6 +116,16 @@ class IliasCrawler:
 
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
 
+    def recursive_crawl_url(self, url: str) -> List[IliasDownloadInfo]:
+        """
+        Crawls a given url *and all reachable elements in it*.
+
+        Args:
+            url {str} -- the *full* url to crawl
+        """
+        start_entries: List[IliasCrawlerEntry] = self._crawl_folder(Path(""), url)
+        return self._iterate_entries_to_download_infos(start_entries)
+
     def crawl_course(self, course_id: str) -> List[IliasDownloadInfo]:
         """
         Starts the crawl process for a course, yielding a list of elements to (potentially)

--- a/PFERD/ilias/crawler.py
+++ b/PFERD/ilias/crawler.py
@@ -249,6 +249,9 @@ class IliasCrawler:
             element: bs4.Tag = soup.find(id="headerimage")
             if "opencast" in element.attrs["src"].lower():
                 PRETTY.warning(f"Switched to crawling a video at {folder_path}")
+                if not self.dir_filter(folder_path, IliasElementType.VIDEO_FOLDER):
+                    PRETTY.not_searching(folder_path, "user filter")
+                    return []
                 return self._crawl_video_directory(folder_path, url)
 
         result: List[IliasCrawlerEntry] = []

--- a/PFERD/ilias/crawler.py
+++ b/PFERD/ilias/crawler.py
@@ -245,6 +245,12 @@ class IliasCrawler:
         """
         soup = self._get_page(url, {})
 
+        if soup.find(id="headerimage"):
+            element: bs4.Tag = soup.find(id="headerimage")
+            if "opencast" in element.attrs["src"].lower():
+                PRETTY.warning(f"Switched to crawling a video at {folder_path}")
+                return self._crawl_video_directory(folder_path, url)
+
         result: List[IliasCrawlerEntry] = []
 
         # Fetch all links and throw them to the general interpreter

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **P**rogramm zum **F**lotten, **E**infachen **R**unterladen von **D**ateien
 
+- [Quickstart with `sync_url`](#quickstart-with-sync_url)
 - [Installation](#installation)
     - [Upgrading from 2.0.0 to 2.1.0+](#upgrading-from-200-to-210)
 - [Example setup](#example-setup)
@@ -11,6 +12,20 @@
         - [Transform creators](#transform-creators)
         - [Transform combinators](#transform-combinators)
     - [A short, but commented example](#a-short-but-commented-example)
+
+## Quickstart with `sync_url`
+
+The `sync_url` program allows you to just synchronize a given ILIAS URL (of a
+course, a folder, your personal desktop, etc.) without any extra configuration
+or setting up. Download the program, open ILIAS, copy the URL from the address
+bar and pass it to sync_url.
+
+It bundles everything it needs in one executable and is easy to
+use, but doesn't expose all the configuration options and tweaks a full install
+does.
+
+1. Download the `sync_url` binary from the [latest release](https://github.com/Garmelon/PFERD/releases/latest).
+2. Run the binary in your terminal (`./sync_url` or `sync_url.exe` in the CMD) to see the help and use it
 
 ## Installation
 

--- a/sync_url.py
+++ b/sync_url.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 
+"""
+A simple script to download a course by name from ILIAS.
+"""
+
 import argparse
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 from PFERD import Pferd
 from PFERD.cookie_jar import CookieJar
-from PFERD.utils import to_path
 from PFERD.ilias.authenticators import KitShibbolethAuthenticator
 from PFERD.ilias.crawler import IliasCrawler
+from PFERD.utils import to_path
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
@@ -18,29 +23,36 @@ def main() -> None:
     parser.add_argument('folder', nargs='?', default=None, help="Folder to put stuff into")
     args = parser.parse_args()
 
-    pferd = Pferd(Path(__file__).parent, test_run=args.test_run)
-    pferd.enable_logging()
-
     # parse provided course URL
     url = urlparse(args.url)
     query = parse_qs(url.query)
-    id = int(query['ref_id'][0])
+    course_id = query['ref_id'][0]
 
-    if args.folder is None:
+    if args.folder is not None:
+        folder = args.folder
+        # Initialize pferd at the *parent of the passed folder*
+        # This is needed so Pferd's internal protections against escaping the working directory
+        # do not trigger (e.g. if somebody names a file in ILIAS '../../bad thing.txt')
+        pferd = Pferd(Path(Path(__file__).parent, folder).parent, test_run=args.test_run)
+    else:
         # fetch course name from ilias
         cookie_jar = CookieJar(to_path(args.cookies) if args.cookies else None)
         session = cookie_jar.create_session()
         authenticator = KitShibbolethAuthenticator()
-        crawler = IliasCrawler(url.scheme + '://' + url.netloc, session, authenticator, lambda x, y: True)
+        crawler = IliasCrawler(url.scheme + '://' + url.netloc, session,
+                               authenticator, lambda x, y: True)
 
         cookie_jar.load_cookies()
         folder = crawler.find_element_name(args.url)
         cookie_jar.save_cookies()
-    else:
-        folder = args.folder
 
+        # Initialize pferd at the location of the script
+        pferd = Pferd(Path(__file__).parent, test_run=args.test_run)
+
+    pferd.enable_logging()
     # fetch
-    pferd.ilias_kit(target=folder, course_id=str(id), cookies=args.cookies)
+    pferd.ilias_kit(target=folder, course_id=course_id, cookies=args.cookies)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR merges the `sync_url` script from @TheChristophe  into master. It also automatically builds that script with pyinstaller and releases it as a github Release when a `v*` tag is pushed ([Sample release](https://github.com/Garmelon/PFERD/releases/tag/v0.0.test)).

This should lower the barrier of entry to:
1. Download the `sync_url` script from the latest release
2. Run it `./sync_url <ilias url>`
3. Profit

The script is by far not as versatile as the normal configurations, but should cover the "I don't want to spend any time on it, just download <some course/folder/video folder>" use case.