### PR TITLE
Fixed description of activating venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ build/
 .env
 .vscode
 ilias_cookies.txt
-*~
 PFERD.egg-info/
 
 # PyInstaller

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 .env
 .vscode
 ilias_cookies.txt
+*~
+PFERD.egg-info/
 
 # PyInstaller
 sync_url.spec

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A full example setup and initial use could look like:
 $ mkdir Vorlesungen
 $ cd Vorlesungen
 $ python3 -m venv .venv
-$ .venv/bin/activate
+$ source .venv/bin/activate
 $ pip install git+https://github.com/Garmelon/PFERD@v2.5.3
 $ curl -O https://raw.githubusercontent.com/Garmelon/PFERD/v2.5.3/example_config.py
 $ python3 example_config.py
@@ -69,7 +69,7 @@ $ deactivate
 Subsequent runs of the program might look like:
 ```
 $ cd Vorlesungen
-$ .venv/bin/activate
+$ source .venv/bin/activate
 $ python3 example_config.py
 $ deactivate
 ```


### PR DESCRIPTION
I fixed the description of the activation of venv because simple `.venv/bin/activate` didn't do the trick. As  `.venv/bin/activate` clearly states the file should rather be activated with the source call.