### PR TITLE
Changed behaviour of kit-ipd-crawler

### DIFF
--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -1,4 +1,5 @@
 import os
+import re
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import List, Set, Union
@@ -89,7 +90,9 @@ class KitIpdCrawler(HttpCrawler):
 
         for element in elements:
             enclosing_table: Tag = element.findParent(name="table")
-            label: Tag = enclosing_table.findPreviousSibling(name="h3")
+            if (enclosing_table) is None:
+                continue
+            label: Tag = enclosing_table.findPreviousSibling(name=re.compile('^h[1-6]$'))
             folder_tags.add(label)
 
         print(folder_tags)
@@ -115,7 +118,7 @@ class KitIpdCrawler(HttpCrawler):
         return KitIpdFile(name, url)
 
     def _find_file_links(self, tag: Union[Tag, BeautifulSoup]) -> List[Tag]:
-        return tag.findAll(name="a", attrs={"href": lambda x: x and "intern" in x})
+        return tag.findAll(name="a", attrs={"href": lambda x: x and ".pdf" in x})
 
     def _abs_url_from_link(self, link_tag: Tag) -> str:
         return urljoin(self._url, link_tag.get("href"))

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -28,7 +28,7 @@ class KitIpdCrawlerSection(HttpCrawlerSection):
         return target
 
     def link_regex(self) -> Pattern[AnyStr]:
-        regex = self.s.get("link_regex", default=".*/[^/]*\.(?:pdf|zip|c|java)")
+        regex = self.s.get("link_regex", ".*/[^/]*\.(?:pdf|zip|c|java)")
         return re.compile(regex)
 
 

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -125,7 +125,7 @@ class KitIpdCrawler(HttpCrawler):
     def _fetch_file_regex(self) -> re.Pattern:
         if "link_regex" in self._config:
             return re.compile(self._config["link_regex"])
-        return re.compile(".*\/[^\/]*\.(?:(?:pdf)|(?:zip)|(?:c)|(?:java))")
+        return re.compile(".*\/[^\/]*\.(?:pdf|zip|c|java)")
     def _abs_url_from_link(self, link_tag: Tag) -> str:
         return urljoin(self._url, link_tag.get("href"))
 

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -93,7 +93,8 @@ class KitIpdCrawler(HttpCrawler):
             if (enclosing_table) is None:
                 continue
             label: Tag = enclosing_table.findPreviousSibling(name=re.compile('^h[1-6]$'))
-            folder_tags.add(label)
+            if label is not None:
+                folder_tags.add(label)
 
         print(folder_tags)
         return folder_tags

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -98,7 +98,6 @@ class KitIpdCrawler(HttpCrawler):
             if label is not None:
                 folder_tags.add(label)
 
-        print(folder_tags)
         return folder_tags
 
     def _extract_folder(self, folder_tag: Tag) -> KitIpdFolder:

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -28,7 +28,7 @@ class KitIpdCrawlerSection(HttpCrawlerSection):
         return target
 
     def link_regex(self) -> Pattern[AnyStr]:
-        regex = self.s.get("link_regex", ".*/[^/]*\.(?:pdf|zip|c|java)")
+        regex = self.s.get("link_regex", "^.*/[^/]*\.(?:pdf|zip|c|java)$")
         return re.compile(regex)
 
 

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -88,17 +88,18 @@ class KitIpdCrawler(HttpCrawler):
         folder_tags: Set[Tag] = set()
 
         for element in elements:
-            enclosing_data: Tag = element.findParent(name="td")
-            label: Tag = enclosing_data.findPreviousSibling(name="td")
+            enclosing_table: Tag = element.findParent(name="table")
+            label: Tag = enclosing_table.findPreviousSibling(name="h3")
             folder_tags.add(label)
 
+        print(folder_tags)
         return folder_tags
 
     def _extract_folder(self, folder_tag: Tag) -> KitIpdFolder:
         name = folder_tag.getText().strip()
         files: List[KitIpdFile] = []
 
-        container: Tag = folder_tag.findNextSibling(name="td")
+        container: Tag = folder_tag.findNextSibling(name="table")
         for link in self._find_file_links(container):
             files.append(self._extract_file(link))
 
@@ -109,10 +110,9 @@ class KitIpdCrawler(HttpCrawler):
         return KitIpdFolder(name, files)
 
     def _extract_file(self, link: Tag) -> KitIpdFile:
-        name = link.getText().strip()
         url = self._abs_url_from_link(link)
-        _, extension = os.path.splitext(url)
-        return KitIpdFile(name + extension, url)
+        name = os.path.basename(url)
+        return KitIpdFile(name, url)
 
     def _find_file_links(self, tag: Union[Tag, BeautifulSoup]) -> List[Tag]:
         return tag.findAll(name="a", attrs={"href": lambda x: x and "intern" in x})


### PR DESCRIPTION
I changed toe behaviour of the kit-ipd-crawler to fit more my [needs](https://pp.ipd.kit.edu/lehre/WS202122/paradigmen/).

For this page it does create a subfolder with a horrific name. I rather think the heading of the table should be used as the folder name. As for the filenames: I find it more advisable to use the actual filename rather than the link-name but perhaps needs vary and should be backed into an option for the crawler.