### PR TITLE
Support named capture groups in regex transformers

### DIFF
--- a/PFERD/transformer.py
+++ b/PFERD/transformer.py
@@ -110,6 +110,10 @@ class ExactReTf(Transformation):
             except ValueError:
                 pass
 
+        named_groups: Dict[str, str] = match.groupdict()
+        for name, capture in named_groups.items():
+            locals_dir[name] = capture
+
         result = eval(f"f{right!r}", {}, locals_dir)
         return Transformed(PurePath(result))
 


### PR DESCRIPTION
Adds support for transforms like
`"Folien zur Vorlesung/(?P<number>\\d{2})(?P<topic>\\w+)-print.pdf" -re-> Folien/Foliensatz_{number}_{topic}.pdf`