### PR TITLE
Use Last-Modified and ETag headers to determine KIT-IPD file versions

### DIFF
--- a/PFERD/crawl/crawler.py
+++ b/PFERD/crawl/crawler.py
@@ -293,6 +293,8 @@ class Crawler(ABC):
     async def download(
             self,
             path: PurePath,
+            *,
+            etag: Optional[str] = None,
             mtime: Optional[datetime] = None,
             redownload: Optional[Redownload] = None,
             on_conflict: Optional[OnConflict] = None,
@@ -307,7 +309,14 @@ class Crawler(ABC):
             log.status("[bold bright_black]", "Ignored", fmt_path(path))
             return None
 
-        fs_token = await self._output_dir.download(path, transformed_path, mtime, redownload, on_conflict)
+        fs_token = await self._output_dir.download(
+            path,
+            transformed_path,
+            etag=etag,
+            mtime=mtime,
+            redownload=redownload,
+            on_conflict=on_conflict
+        )
         if fs_token is None:
             log.explain("Answer: No")
             return None

--- a/PFERD/crawl/crawler.py
+++ b/PFERD/crawl/crawler.py
@@ -294,7 +294,7 @@ class Crawler(ABC):
             self,
             path: PurePath,
             *,
-            etag: Optional[str] = None,
+            etag_differs: Optional[bool] = None,
             mtime: Optional[datetime] = None,
             redownload: Optional[Redownload] = None,
             on_conflict: Optional[OnConflict] = None,
@@ -312,7 +312,7 @@ class Crawler(ABC):
         fs_token = await self._output_dir.download(
             path,
             transformed_path,
-            etag=etag,
+            etag_differs=etag_differs,
             mtime=mtime,
             redownload=redownload,
             on_conflict=on_conflict

--- a/PFERD/crawl/http_crawler.py
+++ b/PFERD/crawl/http_crawler.py
@@ -1,8 +1,9 @@
 import asyncio
 import http.cookies
 import ssl
+from datetime import datetime
 from pathlib import Path, PurePath
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import aiohttp
 import certifi
@@ -14,6 +15,8 @@ from ..logging import log
 from ..utils import fmt_real_path
 from ..version import NAME, VERSION
 from .crawler import Crawler, CrawlerSection
+
+ETAGS_CUSTOM_REPORT_VALUE_KEY = "etags"
 
 
 class HttpCrawlerSection(CrawlerSection):
@@ -168,6 +171,50 @@ class HttpCrawler(Crawler):
         except Exception as e:
             log.warn(f"Failed to save cookies to {fmt_real_path(self._cookie_jar_path)}")
             log.warn(str(e))
+
+    def _get_previous_etag_from_report(self, path: PurePath) -> Optional[str]:
+        """
+        If available, retrieves the entity tag for a given path which was stored in the previous report.
+        """
+        if not self._output_dir.prev_report:
+            return None
+
+        etags = self._output_dir.prev_report.get_custom_value(ETAGS_CUSTOM_REPORT_VALUE_KEY) or {}
+        return etags.get(str(path))
+
+    def _add_etag_to_report(self, path: PurePath, etag: Optional[str]) -> None:
+        """
+        Adds an entity tag for a given path to the report's custom values.
+        """
+        if not etag:
+            return
+
+        etags = self._output_dir.report.get_custom_value(ETAGS_CUSTOM_REPORT_VALUE_KEY) or {}
+        etags[str(path)] = etag
+        self._output_dir.report.add_custom_value(ETAGS_CUSTOM_REPORT_VALUE_KEY, etags)
+
+    async def _request_resource_version(self, resource_url: str) -> Tuple[Optional[str], Optional[datetime]]:
+        """
+        Requests the ETag and Last-Modified headers of a resource via a HEAD request.
+        If no entity tag / modification date can be obtained, the according value will be None.
+        """
+        async with self.session.head(resource_url) as resp:
+            if resp.status != 200:
+                return None, None
+
+            etag_header = resp.headers.get("ETag")
+            last_modified_header = resp.headers.get("Last-Modified")
+
+            if last_modified_header:
+                try:
+                    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified#directives
+                    datetime_format = "%a, %d %b %Y %H:%M:%S GMT"
+                    last_modified = datetime.strptime(last_modified_header, datetime_format)
+                except ValueError:
+                    # last_modified remains None
+                    pass
+
+            return etag_header, last_modified
 
     async def run(self) -> None:
         self._request_count = 0

--- a/PFERD/crawl/http_crawler.py
+++ b/PFERD/crawl/http_crawler.py
@@ -198,23 +198,26 @@ class HttpCrawler(Crawler):
         Requests the ETag and Last-Modified headers of a resource via a HEAD request.
         If no entity tag / modification date can be obtained, the according value will be None.
         """
-        async with self.session.head(resource_url) as resp:
-            if resp.status != 200:
-                return None, None
+        try:
+            async with self.session.head(resource_url) as resp:
+                if resp.status != 200:
+                    return None, None
 
-            etag_header = resp.headers.get("ETag")
-            last_modified_header = resp.headers.get("Last-Modified")
+                etag_header = resp.headers.get("ETag")
+                last_modified_header = resp.headers.get("Last-Modified")
 
-            if last_modified_header:
-                try:
-                    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified#directives
-                    datetime_format = "%a, %d %b %Y %H:%M:%S GMT"
-                    last_modified = datetime.strptime(last_modified_header, datetime_format)
-                except ValueError:
-                    # last_modified remains None
-                    pass
+                if last_modified_header:
+                    try:
+                        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified#directives
+                        datetime_format = "%a, %d %b %Y %H:%M:%S GMT"
+                        last_modified = datetime.strptime(last_modified_header, datetime_format)
+                    except ValueError:
+                        # last_modified remains None
+                        pass
 
-            return etag_header, last_modified
+                return etag_header, last_modified
+        except aiohttp.ClientError:
+            return None, None
 
     async def run(self) -> None:
         self._request_count = 0

--- a/PFERD/crawl/kit_ipd_crawler.py
+++ b/PFERD/crawl/kit_ipd_crawler.py
@@ -178,18 +178,19 @@ class KitIpdCrawler(HttpCrawler):
             if resp.status != 200:
                 return None, None
 
-            etag = resp.headers.get("ETag")
-            last_modified = resp.headers.get("Last-Modified")
+            etag_header = resp.headers.get("ETag")
+            last_modified_header = resp.headers.get("Last-Modified")
 
-            try:
-                # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified#directives
-                datetime_format = "%a, %d %b %Y %H:%M:%S GMT"
-                last_modified = datetime.strptime(last_modified, datetime_format)
-            except ValueError:
-                # last_modified remains None
-                pass
+            if last_modified_header:
+                try:
+                    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified#directives
+                    datetime_format = "%a, %d %b %Y %H:%M:%S GMT"
+                    last_modified = datetime.strptime(last_modified_header, datetime_format)
+                except ValueError:
+                    # last_modified remains None
+                    pass
 
-            return etag, last_modified
+            return etag_header, last_modified
 
     async def get_page(self) -> Tuple[BeautifulSoup, str]:
         async with self.session.get(self._url) as request:

--- a/PFERD/output_dir.py
+++ b/PFERD/output_dir.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path, PurePath
-from typing import BinaryIO, ClassVar, Iterator, Optional, Tuple
+from typing import BinaryIO, Iterator, Optional, Tuple
 
 from .logging import log
 from .report import Report, ReportLoadError


### PR DESCRIPTION
If available, we can use the [Last-Modified](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) header and compare it to the local file's modification time, as well as the [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) header and compare it to previous entity tags. These headers can be obtained via a HEAD request without having to download the entire file. Entity tags are persisted in the `.report` file's custom values for usage in future runs.

Example for [this website](https://scale.iti.kit.edu/teaching/2024ws/param_algo/start):
```sh
$ pferd kit-ipd -T '(?!blatt01).*pdf -re-> !' 'https://scale.iti.kit.edu/teaching/2024ws/param_algo/start' /tmp/paramalgo2024ws_pferd
Downloaded  'blatt01.pdf'
Added       'blatt01.pdf'
$ jq ".custom" /tmp/paramalgo2024ws_pferd/.report
{
  "etags": {
    "blatt01.pdf": "\"8ab8c0af9774abfda5e639e30a21c7f1\""
  }
}
$ pferd --explain --no-report kit-ipd -T '(?!blatt01).*pdf -re-> !' 'https://scale.iti.kit.edu/teaching/2024ws/param_algo/start' /tmp/paramalgo2024ws_pferd
Decision: Download 'blatt01.pdf'
  Testing rule 1: (?!blatt01).*pdf -re-> !
  Final result: 'blatt01.pdf'
  Redownload policy is never-smart
  Remote file's entity tag is the same
  Answer: No
$ jq ".custom.etags.[\"blatt01.pdf\"] = \"xxx\"" /tmp/paramalgo2024ws_pferd/.report | sponge /tmp/paramalgo2024ws_pferd/.report # change etag
$ pferd --explain --no-report kit-ipd -T '(?!blatt01).*pdf -re-> !' 'https://scale.iti.kit.edu/teaching/2024ws/param_algo/start' /tmp/paramalgo2024ws_pferd
Decision: Download 'blatt01.pdf'
  Testing rule 1: (?!blatt01).*pdf -re-> !
  Final result: 'blatt01.pdf'
  Redownload policy is never-smart
  Remote file's entity tag differs
  Answer: Yes
$ jq "del(.custom.etags.[\"blatt01.pdf\"])" /tmp/paramalgo2024ws_pferd/.report | sponge /tmp/paramalgo2024ws_pferd/.report  # remove etag entirely
$ touch -d "1 year ago" blatt01.pdf  # remote mtime is newer than local
$ pferd --explain --no-report kit-ipd -T '(?!blatt01).*pdf -re-> !' 'https://scale.iti.kit.edu/teaching/2024ws/param_algo/start' /tmp/paramalgo2024ws_pferd'https://scale.iti.kit.edu/teaching/2024ws/param_algo/start' /tmp/paramalgo2024ws_pferd
Decision: Download 'blatt01.pdf'
  Testing rule 1: (?!blatt01).*pdf -re-> !
  Final result: 'blatt01.pdf'
  Redownload policy is never-smart
  Remote file seems to be newer
  Answer: Yes
```