### PR TITLE
Store KIT IPD files in folders according to HTML heading structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ ambiguous situations.
 - Remove videos from description pages
 - Perform ILIAS cycle detection after processing the transform to allow
   ignoring duplicated elements
+- Parse headings (h1-h3) as folders in kit-ipd crawler
 
 ### Fixed
 - Personal desktop/dashboard/favorites crawling


### PR DESCRIPTION
Until now, the `kit-ipd` crawlers have stored files that are presented in an HTML table together in a folder. The folder is named after the HTML heading that precedes the table. This is specifically tailored to sites such as [this](https://pp.ipd.kit.edu/lehre/WS202223/paradigmen/).

This PR introduces a more general approach that can construct a nested folder structure. The folders' names are obtained by the HTML structure of (nested) headings without relying on the presence of table elements.

For the example website above, the following file tree is created:
![propa2022ws_pferd_kit_ipd_headings](https://github.com/user-attachments/assets/b93da4be-4603-4e42-a360-588a54445b72)

This might be considered a breaking chance as it is incompatible with the file trees produced by previous runs. (?)