### PR TITLE
Fix check for nonexistent `ilias_url` command attribute to `base_url`

### DIFF
--- a/PFERD/cli/command_ilias_web.py
+++ b/PFERD/cli/command_ilias_web.py
@@ -45,8 +45,8 @@ def load(
     load_crawler(args, section)
 
     section["type"] = COMMAND_NAME
-    if args.ilias_url is not None:
-        section["base_url"] = args.ilias_url
+    if args.base_url is not None:
+        section["base_url"] = args.base_url
     if args.client_id is not None:
         section["client_id"] = args.client_id
 


### PR DESCRIPTION
When using the `ilias-web` crawler via the command line
```bash
pferd ilias-web TARGET OUTPUT ...
```
PFERD crashes. This is because  we check for `args.ilias_url` which doesn't exist, instead of `args.base_url`.