### PR TITLE
Don't recursively walk local-only dirs with NO_DELETE

### DIFF
--- a/PFERD/output_dir.py
+++ b/PFERD/output_dir.py
@@ -501,6 +501,10 @@ class OutputDirectory:
             await self._cleanup_file(path, pure)
 
     async def _cleanup_dir(self, path: Path, pure: PurePath, delete_self: bool = True) -> None:
+        if self._on_conflict in {OnConflict.NO_DELETE, OnConflict.NO_DELETE_PROMPT_OVERWRITE} and not self.report.contains_marked(pure):
+            self._report_not_deleted(pure)
+            return
+
         for child in sorted(path.iterdir()):
             pure_child = pure / child.name
             await self._cleanup(child, pure_child)
@@ -523,8 +527,11 @@ class OutputDirectory:
             except OSError:
                 pass
         else:
-            log.not_deleted("[bold bright_magenta]", "Not deleted", fmt_path(pure))
-            self._report.not_delete_file(pure)
+            self._report_not_deleted(pure)
+
+    def _report_not_deleted(self, path: PurePath) -> None:
+        log.not_deleted("[bold bright_magenta]", "Not deleted", fmt_path(path))
+        self._report.not_delete_file(path)
 
     def load_prev_report(self) -> None:
         log.explain_topic(f"Loading previous report from {fmt_real_path(self._report_path)}")

--- a/PFERD/output_dir.py
+++ b/PFERD/output_dir.py
@@ -531,6 +531,13 @@ class OutputDirectory:
             await self._cleanup_file(path, pure)
 
     async def _cleanup_dir(self, path: Path, pure: PurePath, delete_self: bool = True) -> None:
+        if self._on_conflict in {
+            OnConflict.NO_DELETE,
+            OnConflict.NO_DELETE_PROMPT_OVERWRITE,
+        } and not self.report.contains_marked(pure):
+            self._report_not_deleted(pure)
+            return
+
         for child in sorted(path.iterdir()):
             pure_child = pure / child.name
             await self._cleanup(child, pure_child)
@@ -551,8 +558,11 @@ class OutputDirectory:
             except OSError:
                 pass
         else:
-            log.not_deleted("[bold bright_magenta]", "Not deleted", fmt_path(pure))
-            self._report.not_delete_file(pure)
+            self._report_not_deleted(pure)
+
+    def _report_not_deleted(self, path: PurePath) -> None:
+        log.not_deleted("[bold bright_magenta]", "Not deleted", fmt_path(path))
+        self._report.not_delete_file(path)
 
     def load_prev_report(self) -> None:
         log.explain_topic(f"Loading previous report from {fmt_real_path(self._report_path)}")

--- a/PFERD/report.py
+++ b/PFERD/report.py
@@ -176,6 +176,9 @@ class Report:
     def is_marked(self, path: PurePath) -> bool:
         return path in self.marked
 
+    def contains_marked(self, path: PurePath) -> bool:
+        return any(marked_file.is_relative_to(path) for marked_file in self.marked)
+
     def add_file(self, path: PurePath) -> None:
         """
         Unlike mark(), this function accepts any paths.


### PR DESCRIPTION
This PR consolidates `not deleted` reports/log messages for whole directories that are only available locally. This avoids the performance impact of recursively looking at local-only directories with a lot of files (for example venvs)