### PR TITLE
Sanitize Unicode normalization form for file and directory names

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -92,6 +92,20 @@ common to all crawlers:
   load for the crawl target. (Default: `0.0`)
 - `windows_paths`: Whether PFERD should find alternative names for paths that
   are invalid on Windows. (Default: `yes` on Windows, `no` otherwise)
+- `unicode_normalization`: Which [Unicode normalization form][unicode-norm] to
+  apply to file and directory names before they are written to disk. This is
+  useful on macOS/iOS, where AirDrop silently drops files whose path crosses a
+  precomposed (NFC) non-ASCII directory name; normalizing to `nfd` avoids this.
+  (Default: `none`)
+    - `none`: Names are written as-is, in whatever form the crawler produced
+      (usually NFC).
+    - `nfc`, `nfd`, `nfkc`, `nfkd`: Names are normalized to the respective form.
+
+  Note: changing this option on an already-downloaded directory may cause a
+  one-time re-download and cleanup, since the on-disk names and the previous
+  report use the old form. Starting from a fresh `output_dir` avoids the churn.
+
+[unicode-norm]: <https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize> "unicodedata.normalize"
 
 Some crawlers may also require credentials for authentication. To configure how
 the crawler obtains its credentials, the `auth` option is used. It is set to the

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright 2019-2024 Garmelon, I-Al-Istannen, danstooamerican, pavelzw,
                     TheChristophe, Scriptim, thelukasprobst, Toorero,
-                    Mr-Pine, p-fruck, PinieP
+                    Mr-Pine, p-fruck, PinieP, Florian Raith
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/PFERD/crawl/crawler.py
+++ b/PFERD/crawl/crawler.py
@@ -11,7 +11,15 @@ from ..config import Config, Section
 from ..deduplicator import Deduplicator
 from ..limiter import Limiter
 from ..logging import ProgressBar, log
-from ..output_dir import FileSink, FileSinkToken, OnConflict, OutputDirectory, OutputDirError, Redownload
+from ..output_dir import (
+    FileSink,
+    FileSinkToken,
+    OnConflict,
+    OutputDirectory,
+    OutputDirError,
+    Redownload,
+    UnicodeNormalization,
+)
 from ..report import MarkConflictError, MarkDuplicateError, Report
 from ..transformer import Transformer
 from ..utils import ReusableAsyncContextManager, fmt_path
@@ -175,6 +183,17 @@ class CrawlerSection(Section):
                 str(e).capitalize(),
             )
 
+    def unicode_normalization(self) -> UnicodeNormalization:
+        value = self.s.get("unicode_normalization", "none")
+        try:
+            return UnicodeNormalization.from_string(value)
+        except ValueError as e:
+            self.invalid_value(
+                "unicode_normalization",
+                value,
+                str(e).capitalize(),
+            )
+
     def transform(self) -> str:
         return self.s.get("transform", "")
 
@@ -247,6 +266,7 @@ class Crawler(ABC):
             config.default_section.working_dir() / section.output_dir(name),
             section.redownload(),
             section.on_conflict(),
+            section.unicode_normalization(),
         )
 
     @property

--- a/PFERD/output_dir.py
+++ b/PFERD/output_dir.py
@@ -4,6 +4,7 @@ import os
 import random
 import shutil
 import string
+import unicodedata
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -55,6 +56,27 @@ class OnConflict(Enum):
                 "must be one of 'prompt', 'local-first',"
                 " 'remote-first', 'no-delete', 'no-delete-prompt-overwrite'"
             ) from None
+
+
+class UnicodeNormalization(Enum):
+    NONE = "none"
+    NFC = "nfc"
+    NFD = "nfd"
+    NFKC = "nfkc"
+    NFKD = "nfkd"
+
+    @staticmethod
+    def from_string(string: str) -> "UnicodeNormalization":
+        try:
+            return UnicodeNormalization(string)
+        except ValueError:
+            raise ValueError("must be one of 'none', 'nfc', 'nfd', 'nfkc', 'nfkd'") from None
+
+    def normalize(self, path: PurePath) -> PurePath:
+        if self == UnicodeNormalization.NONE:
+            return path
+        form = self.name  # "NFC", "NFD", "NFKC" or "NFKD"
+        return PurePath(*(unicodedata.normalize(form, part) for part in path.parts))
 
 
 @dataclass
@@ -146,6 +168,7 @@ class OutputDirectory:
         root: Path,
         redownload: Redownload,
         on_conflict: OnConflict,
+        unicode_normalization: UnicodeNormalization = UnicodeNormalization.NONE,
     ):
         if os.name == "nt":
             # Windows limits the path length to 260 for some historical reason.
@@ -158,6 +181,7 @@ class OutputDirectory:
 
         self._redownload = redownload
         self._on_conflict = on_conflict
+        self._unicode_normalization = unicode_normalization
 
         self._report_path = self.resolve(self.REPORT_FILE)
         self._report = Report()
@@ -384,6 +408,7 @@ class OutputDirectory:
         redownload: Optional[Redownload] = None,
         on_conflict: Optional[OnConflict] = None,
     ) -> bool:
+        path = self._unicode_normalization.normalize(path)
         heuristics = Heuristics(etag_differs, mtime)
         redownload = self._redownload if redownload is None else redownload
         on_conflict = self._on_conflict if on_conflict is None else on_conflict
@@ -406,6 +431,7 @@ class OutputDirectory:
         MarkConflictError.
         """
 
+        path = self._unicode_normalization.normalize(path)
         heuristics = Heuristics(etag_differs, mtime)
         redownload = self._redownload if redownload is None else redownload
         on_conflict = self._on_conflict if on_conflict is None else on_conflict


### PR DESCRIPTION
### Add a `unicode_normalization` option for crawlers

Ran into this while downloading a course and then trying to AirDrop the folder to my iPad: everything under the umlaut directories (Übung/, Werbung für Hochschulgruppen/, ...) just silently disappeared, while the ASCII-named folders transferred fine.

Turns out it's a Unicode normalization thing. PFERD writes names in NFC (ü = one code point), which is totally fine locally since APFS (apple file system) doesn't care about the difference. But AirDrop re-normalizes paths to NFD (u + combining mark) when rebuilding the file tree on the other device, and for entries whose path crosses an NFC directory name that step fails and the files just get dropped. So even though the actual filenames are pure ASCII (ss20_aufgaben.pdf), the umlaut parent directory is enough to break it.

This adds a `unicode_normalization` crawler option to control the form names are written in:

```ini
[crawl:something]
unicode_normalization = nfd
```

Accepts `none` (default), `nfc`, `nfd`, `nfkc` and `nfkd`. Default is `none`, so nothing changes unless you opt in (setting it to nfd fixes the AirDrop problem for me).

The normalization happens in OutputDirectory right before the path is used, so the report, the names on disk and the cleanup all agree on the same form (otherwise cleanup would think everything changed and re-download the whole tree every run). Heads up that switching it on for an already-downloaded folder can cause a one-time re-download since the old names are still in the previous form (mentioned that in the docs).

`nfd` is probably a sensible default for macOS/iOS, but I didn't want to cause any breaking changes, so for this PR it's opt-in only.
